### PR TITLE
Add required metadata for Maven Central publishing

### DIFF
--- a/cdap-metrics-writer-ext-gcp-monitoring/pom.xml
+++ b/cdap-metrics-writer-ext-gcp-monitoring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © 2021 Cask Data, Inc.
+  ~ Copyright © 2025 Cask Data, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
   ~ use this file except in compliance with the License. You may obtain a copy of
@@ -29,6 +29,32 @@
   <name>CDAP metrics writer extension for Google Cloud Monitoring</name>
   <packaging>jar</packaging>
 
+  <description>Google Cloud Monitoring Writer</description>
+  <url>https://github.com/cdapio/metrics-writer-extension</url>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Cask Data</name>
+      <email>cask-dev@googlegroups.com</email>
+      <organization>Cask Data, Inc.</organization>
+      <organizationUrl>http://www.cdap.io</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/cdapio/metrics-writer-extension.git</connection>
+    <developerConnection>scm:git:git@github.com:cdapio/metrics-writer-extension.git</developerConnection>
+    <url>https://github.com/cdapio/metrics-writer-extension.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
@@ -46,4 +72,76 @@
       <version>31.0.1-jre</version>
     </dependency>
   </dependencies>
+
+  <!-- Profile for release. Includes building of source and javadoc jars. -->
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <!-- Source JAR -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <configuration>
+              <excludeResources>true</excludeResources>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Javadoc jar -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+              <failOnError>false</failOnError>
+              <links>
+                <link>http://download.oracle.com/javase/${jee.version}/docs/api/</link>
+              </links>
+              <doctitle>${project.name} ${project.version}</doctitle>
+              <bottom>
+                <![CDATA[Copyright &#169; {currentYear} <a href="http://cdap.io" target="_blank">CDAP</a> Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache License, Version 2.0</a>.]]>
+              </bottom>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadoc</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- GPG signature -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <configuration>
+              <passphrase>${gpg.passphrase}</passphrase>
+              <useAgent>${gpg.useagent}</useAgent>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
### Description

This PR configures the project to meet the requirements for publishing artifacts to the Maven Central repository

Below are the error mentioned.
 
```
pkg:maven/io.cdap.cdap/cdap-metrics-writer-ext-gcp-monitoring@1.4.0
9
Sources must be provided but not found in entries
Javadocs must be provided but not found in entries
Missing signature for file: cdap-metrics-writer-ext-gcp-monitoring-1.4.0.pom
Missing signature for file: cdap-metrics-writer-ext-gcp-monitoring-1.4.0.jar
Project description is missing
Project URL is not defined
License information is missing
SCM URL is not defined
Developers information is missing
```



